### PR TITLE
Go sqlite library has been moved

### DIFF
--- a/imdb/sqlite.go
+++ b/imdb/sqlite.go
@@ -3,5 +3,5 @@
 package imdb
 
 import (
-	_ "code.google.com/p/go-sqlite/go1/sqlite3"
+	_ "github.com/mxk/go-sqlite/sqlite3"
 )


### PR DESCRIPTION
Fixes warning on go get:
warning: code.google.com is shutting down; import path code.google.com/p/go-sqlite/go1/sqlite3 will stop working
